### PR TITLE
Update README.md for solving [XSIM 43-3409] Failed to compile generat…

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ These libraries should be installed for the Vivado GUI features (to export schem
 
 ```sh
 sudo apt update
-sudo apt install -y libxrender1 libxtst6 libxi6 
+sudo apt install -y libxrender1 libxtst6 libxi6
+sudo apt install build-essential
+
 ```
 
 Link the `gcc` that came installed with Vivado to **/usr/bin** because it will be needed when running simulations.


### PR DESCRIPTION
…ed C file error

So while i saw trying to simulate i encountered an error 

[XSIM 43-3409] Failed to compile generated C file

So i solved it via following the best answer in:
https://support.xilinx.com/s/question/0D52E00006iHlpQSAS/vivado-20172-simulation-xsim-433409-failed-to-compile-generated-c-file?language=en_US

so i just installed new packages 
sudo apt install build-essential